### PR TITLE
[AA] Laravel 5.8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,12 @@
     "keywords": ["laravel", "multi-tenant", "saas", "tenancy", "aws", "gce"],
     "license": "MIT",
     "require": {
-        "laravel/framework": "5.7.*",
+        "laravel/framework": "5.8.*",
         "psr/container": "^1.0.0"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.7",
-        "laravel/laravel": "5.7.*",
+        "laravel/laravel": "5.8.*",
         "phpunit/phpunit": "^7.0",
         "mockery/mockery": "^1.0",
         "squizlabs/php_codesniffer": "^3.3",

--- a/src/Tenancy/Identification/Support/TenantModelCollection.php
+++ b/src/Tenancy/Identification/Support/TenantModelCollection.php
@@ -15,6 +15,7 @@
 namespace Tenancy\Identification\Support;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Arr;
 
 class TenantModelCollection extends Collection
 {
@@ -24,7 +25,7 @@ class TenantModelCollection extends Collection
      */
     public function filterByContract($contracts)
     {
-        $contracts = array_wrap($contracts);
+        $contracts = Arr::wrap($contracts);
 
         return $this->filter(function (string $item) use ($contracts) {
             $implements = class_implements($item);

--- a/src/Tenancy/Providers/TenantProvider.php
+++ b/src/Tenancy/Providers/TenantProvider.php
@@ -22,7 +22,6 @@ use Illuminate\Contracts\Support\DeferrableProvider;
 
 class TenantProvider extends ServiceProvider implements DeferrableProvider
 {
-
     public function boot()
     {
         $this->app->bind(Tenant::class, function (Application $app) {

--- a/src/Tenancy/Providers/TenantProvider.php
+++ b/src/Tenancy/Providers/TenantProvider.php
@@ -18,10 +18,10 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Tenancy\Identification\Contracts\ResolvesTenants;
 use Tenancy\Identification\Contracts\Tenant;
+use Illuminate\Contracts\Support\DeferrableProvider;
 
-class TenantProvider extends ServiceProvider
+class TenantProvider extends ServiceProvider implements DeferrableProvider
 {
-    protected $defer = true;
 
     public function boot()
     {

--- a/src/Tenancy/Providers/TenantProvider.php
+++ b/src/Tenancy/Providers/TenantProvider.php
@@ -16,9 +16,9 @@ namespace Tenancy\Providers;
 
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Support\DeferrableProvider;
 use Tenancy\Identification\Contracts\ResolvesTenants;
 use Tenancy\Identification\Contracts\Tenant;
-use Illuminate\Contracts\Support\DeferrableProvider;
 
 class TenantProvider extends ServiceProvider implements DeferrableProvider
 {

--- a/src/Tenancy/composer.json
+++ b/src/Tenancy/composer.json
@@ -5,7 +5,8 @@
     "license": "MIT",
     "require": {
         "laravel/framework": "5.8.*",
-        "psr/container": "^1.0.0"
+        "psr/container": "^1.0.0",
+        "laravel/helpers": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -33,5 +34,7 @@
                 "Tenancy": "Tenancy\\Facades\\TenancyFacade"
             }
         }
+    },
+    "require-dev": {
     }
 }

--- a/src/Tenancy/composer.json
+++ b/src/Tenancy/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel", "multi-tenant", "saas", "tenancy", "aws", "gce"],
     "license": "MIT",
     "require": {
-        "laravel/framework": "5.7.*",
+        "laravel/framework": "5.8.*",
         "psr/container": "^1.0.0"
     },
     "autoload": {

--- a/src/Tenancy/composer.json
+++ b/src/Tenancy/composer.json
@@ -5,8 +5,7 @@
     "license": "MIT",
     "require": {
         "laravel/framework": "5.8.*",
-        "psr/container": "^1.0.0",
-        "laravel/helpers": "^1.0"
+        "psr/container": "^1.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As per Laravel 5.8 the Defer variable in Service Providers is [deprecated](https://github.com/laravel/framework/pull/27067). This PR simply fixes the deferrable provider per their requirements, would break compatibility with 5.7 though.