### PR TITLE
Add Psalm to CircleCi build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,17 @@ jobs:
         - attach_workspace:
               at: ./
         - run: ./vendor/bin/phpstan analyse
+
+    psalm:
+        docker:
+        - image: php:7.2
+        working_directory: ~/repo
+        steps:
+        - checkout
+        - attach_workspace:
+              at: ./
+        - run: ./vendor/bin/psalm --show-info=false
+
     coverage:
         docker:
             - image: php:7.2

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,10 @@
         "phpunit/phpunit": "^7.0",
         "mockery/mockery": "^1.0",
         "squizlabs/php_codesniffer": "^3.3",
-        "nunomaduro/larastan": "^0.3.15"
+        "nunomaduro/larastan": "^0.3.15",
+        "psalm/plugin-laravel": "^0.0.5",
+        "vimeo/psalm": "^3.1",
+        "zendframework/zend-diactoros": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="false"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config file:///Users/matthewbrown/Desktop/vimeo/git/tenancy-framework/vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <LessSpecificReturnType errorLevel="info"/>
+
+        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
+
+        <DeprecatedMethod errorLevel="info"/>
+        <DeprecatedProperty errorLevel="info"/>
+        <DeprecatedClass errorLevel="info"/>
+        <DeprecatedConstant errorLevel="info"/>
+        <DeprecatedInterface errorLevel="info"/>
+        <DeprecatedTrait errorLevel="info"/>
+
+        <InternalMethod errorLevel="info"/>
+        <InternalProperty errorLevel="info"/>
+        <InternalClass errorLevel="info"/>
+
+        <MissingClosureReturnType errorLevel="info"/>
+        <MissingReturnType errorLevel="info"/>
+        <MissingPropertyType errorLevel="info"/>
+        <InvalidDocblock errorLevel="info"/>
+        <MisplacedRequiredParam errorLevel="info"/>
+
+        <PropertyNotSetInConstructor errorLevel="info"/>
+        <MissingConstructor errorLevel="info"/>
+        <MissingClosureParamType errorLevel="info"/>
+        <MissingParamType errorLevel="info"/>
+
+        <RedundantCondition errorLevel="info"/>
+
+        <DocblockTypeContradiction errorLevel="info"/>
+        <RedundantConditionGivenDocblockType errorLevel="info"/>
+
+        <UnresolvableInclude errorLevel="info"/>
+
+        <RawObjectIteration errorLevel="info"/>
+
+        <InvalidStringClass errorLevel="info"/>
+    </issueHandlers>
+<plugins><pluginClass class="Psalm\LaravelPlugin\Plugin"/></plugins></psalm>


### PR DESCRIPTION
This adds Psalm to your build. Psalm is a little more flexible than PHPStan, as it won't emit fatal errors when there are issues with PHP incompatibility.